### PR TITLE
adapted for 11-oss_bsp-vndk common vendor tree

### DIFF
--- a/j6lte-vendor.mk
+++ b/j6lte-vendor.mk
@@ -45,4 +45,4 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     vendor/samsung/j6lte/proprietary/vendor/etc/Tfa9896.cnt:$(TARGET_COPY_OUT_VENDOR)/etc/Tfa9896.cnt \
     vendor/samsung/universal7870-common/proprietary/audio/m10lte/lib/libtfa98xx.so:$(TARGET_COPY_OUT_VENDOR)/lib/libtfa98xx.so \
-    vendor/samsung/universal7870-common/proprietary/audio/m10lte/lib/hw/audio.primary.universal7870.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/audio.primary.universal7870.so 
+    vendor/samsung/universal7870-common/proprietary/vendor/lib/hw/audio.primary.universal7870.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/audio.primary.universal7870.so 


### PR DESCRIPTION
fixed vendor/proprietary/audio/m10lte/lib/hw/audio.primary.universal7870.so not found error